### PR TITLE
Added immediate exit if config not provided

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -68,6 +68,13 @@ password=""
 save_for_reuse=""
 profile_name=""
 
+
+if [[ "$1" == "load" && "$2" == "" ]]; then
+    echo -ne "\e[1m \e[31mPlease provide a config! \e[0m"
+    echo
+    exit
+fi 
+
 if [ "$1" == "load" ]; then
     choice="set"
 
@@ -128,12 +135,6 @@ Tool to set up system wide proxy settings on Linux.
         fi
     fi
 fi
-
-if [[ "$1" == "load" && "$2" == "" ]]; then
-    echo -ne "\e[1m \e[31mPlease provide a config! \e[0m"
-    echo
-    exit
-fi 
 
 echo
 echo -e " \e[0m\e[4m\e[33mEnter targets where you want to modify settings : \e[0m"

--- a/main.sh
+++ b/main.sh
@@ -129,6 +129,12 @@ Tool to set up system wide proxy settings on Linux.
     fi
 fi
 
+if [[ "$1" == "load" && "$2" == "" ]]; then
+    echo -ne "\e[1m \e[31mPlease provide a config! \e[0m"
+    echo
+    exit
+fi 
+
 echo
 echo -e " \e[0m\e[4m\e[33mEnter targets where you want to modify settings : \e[0m"
 echo -e " |\e[36m 1 \e[0m| All of them ... Don't bother me"


### PR DESCRIPTION
- Right now, `./main.sh load` will still ask for targets before exiting. This has been corrected in this PR.