### PR TITLE
Git file remove sections instead of unset

### DIFF
--- a/git.sh
+++ b/git.sh
@@ -11,8 +11,8 @@ list_proxy() {
 }
 
 unset_proxy() {
-    git config --global --unset http.proxy
-    git config --global --unset https.proxy
+    git config --global --remove-section http
+    git config --global --remove-section https
 }
 
 set_proxy() {


### PR DESCRIPTION
--unset http.proxy and --unset https.proxy  leaves blanks http and https sections , next time will create again this sections.
by --remove-section http or --remove-section https will completely remove seccions leaving .gitconfig file clean for next "proxyman load"