### PR TITLE
fix: handling symlinks for bashrc and zshrc files

### DIFF
--- a/apt.sh
+++ b/apt.sh
@@ -28,7 +28,7 @@ unset_proxy() {
         return
     fi
     if [ "$(cat $CONF_FILE | grep proxy -i | wc -l)" -gt 0 ]; then
-        sed -E "/^Acquire::(.)*::Proxy/d" $CONF_FILE -i
+        sed -E "/^Acquire::(.)*::Proxy/d" $CONF_FILE -i --follow-symlinks
     fi
 }
 

--- a/apt.sh
+++ b/apt.sh
@@ -3,7 +3,7 @@
 # privileges has to be set by the process which starts this script
 
 
-CONF_FILE="/etc/apt/apt.conf"
+CONF_FILE=`readlink -f /etc/apt/apt.conf`
 
 fix_new_line() {
     if [[ $(tail -c 1 "$CONF_FILE" | wc --lines ) = 0 ]]; then
@@ -28,7 +28,7 @@ unset_proxy() {
         return
     fi
     if [ "$(cat $CONF_FILE | grep proxy -i | wc -l)" -gt 0 ]; then
-        sed -E "/^Acquire::(.)*::Proxy/d" $CONF_FILE -i --follow-symlinks
+        sed -E "/^Acquire::(.)*::Proxy/d" $CONF_FILE -i
     fi
 }
 

--- a/bash-zsh.sh
+++ b/bash-zsh.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+BASHRC=`readlink -f $HOME/.bashrc`
+ZSHRC=`readlink -f $HOME/.zshrc`
+
 which bash &> /dev/null
 first="$?"
 
@@ -11,7 +14,7 @@ if [ "$#" = 0 ]; then
 fi
 
 if [ "$first" = 0 ]; then
-    bash shellrc.sh "$1" "$HOME/.bashrc"
+    bash shellrc.sh "$1" "$BASHRC"
     if [ ! "$1" = "list" ]; then
         echo "To activate in current terminal window"
         echo "run ${bold}source ~/.bashrc${normal}"
@@ -19,7 +22,7 @@ if [ "$first" = 0 ]; then
 fi
 
 if [ "$second" = 0 ]; then
-    bash shellrc.sh "$1" "$HOME/.zshrc"
+    bash shellrc.sh "$1" "$ZSHRC"
     if [ ! "$1" = "list" ]; then
         echo "To activate in current terminal window"
         echo "run ${bold}source ~/.zshrc${normal}"

--- a/dnf.sh
+++ b/dnf.sh
@@ -28,7 +28,7 @@ unset_proxy() {
         return
     fi
     if [ "$(cat $CONF_FILE | grep proxy -i | wc -l)" -gt 0 ]; then
-        sed "/proxy/d" $CONF_FILE -i
+        sed "/proxy/d" $CONF_FILE -i --follow-symlinks
     fi
 }
 

--- a/dnf.sh
+++ b/dnf.sh
@@ -3,7 +3,7 @@
 # privileges has to be set by the process which starts this script
 
 
-CONF_FILE="/etc/dnf/dnf.conf"
+CONF_FILE=`readlink -f /etc/dnf/dnf.conf`
 
 fix_new_line() {
     if [[ $(tail -c 1 "$CONF_FILE" | wc --lines ) = 0 ]]; then
@@ -28,7 +28,7 @@ unset_proxy() {
         return
     fi
     if [ "$(cat $CONF_FILE | grep proxy -i | wc -l)" -gt 0 ]; then
-        sed "/proxy/d" $CONF_FILE -i --follow-symlinks
+        sed "/proxy/d" $CONF_FILE -i
     fi
 }
 

--- a/docker.sh
+++ b/docker.sh
@@ -34,7 +34,7 @@ unset_proxy() {
         return
     fi
     for PROTOTYPE in "HTTP" "HTTPS" "FTP" "RSYNC" "NO"; do
-        sed -i "/${PROTOTYPE}_PROXY\=/d" "$CONF_FILE"
+        sed -i --follow-symlinks "/${PROTOTYPE}_PROXY\=/d" "$CONF_FILE"
     done
 }
 

--- a/docker.sh
+++ b/docker.sh
@@ -2,7 +2,7 @@
 # plugin to set "dnf" proxy settings for ProxyMan
 # privileges has to be set by the process which starts this script
 
-CONF_FILE="/etc/systemd/system/docker.service.d/http-proxy.conf"
+CONF_FILE=`readlink -f /etc/systemd/system/docker.service.d/http-proxy.conf`
 
 
 reload_docker_service() {
@@ -34,7 +34,7 @@ unset_proxy() {
         return
     fi
     for PROTOTYPE in "HTTP" "HTTPS" "FTP" "RSYNC" "NO"; do
-        sed -i --follow-symlinks "/${PROTOTYPE}_PROXY\=/d" "$CONF_FILE"
+        sed -i "/${PROTOTYPE}_PROXY\=/d" "$CONF_FILE"
     done
 }
 

--- a/shellrc.sh
+++ b/shellrc.sh
@@ -25,10 +25,10 @@ unset_proxy() {
     # extra effort required to avoid removing custom environment variables set
     # by the user for personal use
     for proxytype in "http" "https" "ftp" "rsync" "no"; do
-        sed -i "/export ${proxytype}_proxy\=/d" "$SHELLRC"
+        sed -i --follow-symlinks "/export ${proxytype}_proxy\=/d" "$SHELLRC"
     done
     for PROTOTYPE in "HTTP" "HTTPS" "FTP" "RSYNC" "NO"; do
-        sed -i "/export ${PROTOTYPE}_PROXY\=/d" "$SHELLRC"
+        sed -i --follow-symlinks "/export ${PROTOTYPE}_PROXY\=/d" "$SHELLRC"
     done
 }
 

--- a/shellrc.sh
+++ b/shellrc.sh
@@ -25,10 +25,10 @@ unset_proxy() {
     # extra effort required to avoid removing custom environment variables set
     # by the user for personal use
     for proxytype in "http" "https" "ftp" "rsync" "no"; do
-        sed -i --follow-symlinks "/export ${proxytype}_proxy\=/d" "$SHELLRC"
+        sed -i "/export ${proxytype}_proxy\=/d" "$SHELLRC"
     done
     for PROTOTYPE in "HTTP" "HTTPS" "FTP" "RSYNC" "NO"; do
-        sed -i --follow-symlinks "/export ${PROTOTYPE}_PROXY\=/d" "$SHELLRC"
+        sed -i "/export ${PROTOTYPE}_PROXY\=/d" "$SHELLRC"
     done
 }
 


### PR DESCRIPTION
If you are using symlinks to store your .bashrc or .zshrc file elsewhere, ProxyMan will overwrite them when setting or unsetting them.

With this fix, this will allow people to use symlinks for these configuration files.