### PR TITLE
Support /etc/environment

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+bash shellrc.sh "$1" "/etc/environment"

--- a/main.sh
+++ b/main.sh
@@ -19,7 +19,9 @@ function _do_it_for_all() {
     local what_to_do="$1"
     if [[ -z "$targets" || "$targets" = "1" ]]; then
         bash "bash-zsh.sh" "$what_to_do"
-        # sudo bash "environment.sh" "$what_to_do"
+	# avoiding /etc/environment in all because it requires logout after unset
+	# bashrc / zshrc is sufficient, and sudo -E might suffice
+        # sudo -E bash "environment.sh" "$what_to_do"
         bash "gsettings.sh" "$what_to_do"
         bash "kde5.sh" "$what_to_do"
         bash "npm.sh" "$what_to_do"

--- a/main.sh
+++ b/main.sh
@@ -21,7 +21,9 @@ function _do_it_for_all() {
         bash "bash-zsh.sh" "$what_to_do"
 	# avoiding /etc/environment in all because it requires logout after unset
 	# bashrc / zshrc is sufficient, and sudo -E might suffice
-        # sudo -E bash "environment.sh" "$what_to_do"
+	if [[ "$what_to_do" = "list" ]]; then
+            sudo -E bash "environment.sh" "$what_to_do"
+        fi
         bash "gsettings.sh" "$what_to_do"
         bash "kde5.sh" "$what_to_do"
         bash "npm.sh" "$what_to_do"


### PR DESCRIPTION
 Currently, `/etc/environment` was intentionally unsupported because on unset it requires a logout (restart of current login shell).

This PR allows setting on request, when specified by user
However, `set/unset` at all locations still exclude `/etc/environment`.