### PR TITLE
Add macOS support

### DIFF
--- a/bash-zsh.sh
+++ b/bash-zsh.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 
-BASHRC=`readlink -f $HOME/.bashrc`
-ZSHRC=`readlink -f $HOME/.zshrc`
+case $os in
+    "Linux") 
+        BASHRC=`readlink -f $HOME/.bashrc`
+        ZSHRC=`readlink -f $HOME/.zshrc`
+    ;;
+    "Darwin") 
+        BASHRC=`realpath $HOME/.zshrc`
+        ZSHRC=`realpath $HOME/.zshrc`
+    ;;
+    *) echo "Operating system not supported. Exiting."
+       exit 1
+    ;;
+esac
 
 which bash &> /dev/null
 first="$?"

--- a/main.sh
+++ b/main.sh
@@ -11,62 +11,16 @@
 source "./variables.sh"
 source "./configs.sh"
 
-
-function _do_it_for_all() {
-    # Argument
-    # $1 : what to do (set/unset/list)
-
-    local what_to_do="$1"
-    if [[ -z "$targets" || "$targets" = "1" ]]; then
-        bash "bash-zsh.sh" "$what_to_do"
-	# avoiding /etc/environment in all because it requires logout after unset
-	# bashrc / zshrc is sufficient, and sudo -E might suffice
-	if [[ "$what_to_do" = "list" ]]; then
-            sudo -E bash "environment.sh" "$what_to_do"
-        fi
-        bash "gsettings.sh" "$what_to_do"
-        bash "kde5.sh" "$what_to_do"
-        bash "npm.sh" "$what_to_do"
-        bash "dropbox.sh" "$what_to_do"
-        bash "git.sh" "$what_to_do"
-
-        # isn't required, but still checked to avoid sudo in main all the time
-        SUDO_CMDS="apt dnf docker"
-        for cmd in $SUDO_CMDS; do
-            command -v $cmd > /dev/null && sudo -E bash "${cmd}.sh" "$what_to_do" || :
-        done
-    else
-        for t in "${targets[@]}"
-        do
-            case "$t" in
-                # THIS stmt WILL CAUSE INFINITE RECURSION. DO NOT USE THIS.
-                # COMMENTED FOR WARNING
-                # 1) _do_it_for_all "$what_to_do"
-                #    ;;
-                2) bash "bash-zsh.sh" "$what_to_do"
-                   ;;
-                3) sudo -E bash "environment.sh" "$what_to_do"
-                   ;;
-                4) sudo -E bash "apt.sh" "$what_to_do"
-                   sudo -E bash "dnf.sh" "$what_to_do"
-                   ;;
-                5) bash "gsettings.sh" "$what_to_do"
-                   bash "kde5.sh" "$what_to_do"
-                   ;;
-                6) bash "npm.sh" "$what_to_do"
-                   ;;
-                7) bash "dropbox.sh" "$what_to_do"
-                   ;;
-                8) bash "git.sh" "$what_to_do"
-                   ;;
-                9) sudo -E bash "docker.sh" "$what_to_do"
-                   ;;
-                *) ;;
-            esac
-        done
-
-    fi
-}
+# Load main functions for current operating system
+case $os in
+    "Linux") source "./main_linux.sh"
+    ;;
+    "Darwin") source "./main_macos.sh"
+    ;;
+    *) echo "Operating system not supported. Exiting."
+       exit 1
+    ;;
+esac
 
 function _dump_it_all() {
     echo "HTTP  > $http_host $http_port"
@@ -138,24 +92,6 @@ function prompt_for_proxy_values() {
     fi
 
     echo
-}
-
-function prompt_for_proxy_targets() {
-    echo "${bold}${blue} Select targets to modify ${normal}"
-
-    echo "|${bold}${red} 1 ${normal}| All of them ... Don't bother me"
-    echo "|${bold}${red} 2 ${normal}| Terminal / bash / zsh (current user) "
-    echo "|${bold}${red} 3 ${normal}| /etc/environment"
-    echo "|${bold}${red} 4 ${normal}| apt/dnf (Package manager)"
-    echo "|${bold}${red} 5 ${normal}| Desktop settings (GNOME/Ubuntu/KDE)"
-    echo "|${bold}${red} 6 ${normal}| npm & yarn"
-    echo "|${bold}${red} 7 ${normal}| Dropbox"
-    echo "|${bold}${red} 8 ${normal}| Git"
-    echo "|${bold}${red} 9 ${normal}| Docker"
-    echo
-    echo "Separate multiple choices with space"
-    echo -ne "\e[5m ? \e[0m" ; read targets
-    export targets=(`echo ${targets}`)
 }
 
 function main() {

--- a/main_linux.sh
+++ b/main_linux.sh
@@ -21,10 +21,10 @@ function _do_it_for_selection() {
             3) sudo -E bash "environment.sh" "$what_to_do"
                 ;;
             4) sudo -E bash "apt.sh" "$what_to_do"
-                sudo -E bash "dnf.sh" "$what_to_do"
+               sudo -E bash "dnf.sh" "$what_to_do"
                 ;;
             5) bash "gsettings.sh" "$what_to_do"
-                bash "kde5.sh" "$what_to_do"
+               bash "kde5.sh" "$what_to_do"
                 ;;
             6) bash "npm.sh" "$what_to_do"
                 ;;

--- a/main_linux.sh
+++ b/main_linux.sh
@@ -81,6 +81,6 @@ function prompt_for_proxy_targets() {
     echo "|${bold}${red} 9 ${normal}| Docker"
     echo
     echo "Separate multiple choices with space"
-    echo -n "${bold} ? ${normal}" ; read targets # 
+    echo -n "${bold} ? ${normal}" ; read targets
     export targets=(`echo ${targets}`)
 }

--- a/main_linux.sh
+++ b/main_linux.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# If you have found some issues, or some feature request :
+# Raise them here : https://github.com/himanshub16/ProxyMan/issues
+# Author : Himanshu Shekhar (@himanshub16)
+#
+
+# This is the script that provides main script functions for Linux.
+
+function _do_it_for_selection() {
+    local what_to_do="$1"
+    for t in "${targets[@]}"
+    do
+        case "$t" in
+            # THIS stmt WILL CAUSE INFINITE RECURSION. DO NOT USE THIS.
+            # COMMENTED FOR WARNING
+            # 1) _do_it_for_all "$what_to_do"
+            #    ;;
+            2) bash "bash-zsh.sh" "$what_to_do"
+                ;;
+            3) sudo -E bash "environment.sh" "$what_to_do"
+                ;;
+            4) sudo -E bash "apt.sh" "$what_to_do"
+                sudo -E bash "dnf.sh" "$what_to_do"
+                ;;
+            5) bash "gsettings.sh" "$what_to_do"
+                bash "kde5.sh" "$what_to_do"
+                ;;
+            6) bash "npm.sh" "$what_to_do"
+                ;;
+            7) bash "dropbox.sh" "$what_to_do"
+                ;;
+            8) bash "git.sh" "$what_to_do"
+                ;;
+            9) sudo -E bash "docker.sh" "$what_to_do"
+                ;;
+            *) ;;
+        esac
+    done
+}
+
+function _do_it_for_all() {
+    # Argument
+    # $1 : what to do (set/unset/list)
+
+    local what_to_do="$1"
+    if [[ -z "$targets" || "$targets" = "1" ]]; then
+        bash "bash-zsh.sh" "$what_to_do"
+	# avoiding /etc/environment in all because it requires logout after unset
+	# bashrc / zshrc is sufficient, and sudo -E might suffice
+	if [[ "$what_to_do" = "list" ]]; then
+            sudo -E bash "environment.sh" "$what_to_do"
+        fi
+        bash "gsettings.sh" "$what_to_do"
+        bash "kde5.sh" "$what_to_do"
+        bash "npm.sh" "$what_to_do"
+        bash "dropbox.sh" "$what_to_do"
+        bash "git.sh" "$what_to_do"
+
+        # isn't required, but still checked to avoid sudo in main all the time
+        SUDO_CMDS="apt dnf docker"
+        for cmd in $SUDO_CMDS; do
+            command -v $cmd > /dev/null && sudo -E bash "${cmd}.sh" "$what_to_do" || :
+        done
+    else
+        _do_it_for_selection "$what_to_do"
+    fi
+}
+
+function prompt_for_proxy_targets() {
+    echo "${bold}${blue} Select targets to modify ${normal}"
+
+    echo "|${bold}${red} 1 ${normal}| All of them ... Don't bother me"
+    echo "|${bold}${red} 2 ${normal}| Terminal / bash / zsh (current user) "
+    echo "|${bold}${red} 3 ${normal}| /etc/environment"
+    echo "|${bold}${red} 4 ${normal}| apt/dnf (Package manager)"
+    echo "|${bold}${red} 5 ${normal}| Desktop settings (GNOME/Ubuntu/KDE)"
+    echo "|${bold}${red} 6 ${normal}| npm & yarn"
+    echo "|${bold}${red} 7 ${normal}| Dropbox"
+    echo "|${bold}${red} 8 ${normal}| Git"
+    echo "|${bold}${red} 9 ${normal}| Docker"
+    echo
+    echo "Separate multiple choices with space"
+    echo -n "${bold} ? ${normal}" ; read targets # 
+    export targets=(`echo ${targets}`)
+}

--- a/main_macos.sh
+++ b/main_macos.sh
@@ -9,7 +9,7 @@
 
 function _do_it_for_selection() {
     local what_to_do="$1"
-    for t in "${targets[@]}"
+    for t in ${targets[@]}
     do
         case "$t" in
             # THIS stmt WILL CAUSE INFINITE RECURSION. DO NOT USE THIS.
@@ -18,11 +18,11 @@ function _do_it_for_selection() {
             #    ;;
             2) bash "bash-zsh.sh" "$what_to_do"
                 ;;
-            3) bash "npm.sh" "$what_to_do"
+            3) bash "networksetup.sh" "$what_to_do"
                 ;;
-            3) echo "networksetup not yet implemented. skipping." #bash "networksetup.sh" "$what_to_do"
+            4) bash "npm.sh" "$what_to_do"
                 ;;
-            4) bash "git.sh" "$what_to_do"
+            5) bash "git.sh" "$what_to_do"
                 ;;
             *) ;;
         esac
@@ -37,6 +37,7 @@ function _do_it_for_all() {
     if [[ -z "$targets" || "$targets" = "1" ]]; then
 
         bash "bash-zsh.sh" "$what_to_do"
+        # bash "networksetup.sh" "$what_to_do"
         bash "npm.sh" "$what_to_do"
         bash "git.sh" "$what_to_do"
 
@@ -55,6 +56,6 @@ function prompt_for_proxy_targets() {
     echo "|${bold}${red} 5 ${normal}| Git"
     echo
     echo "Separate multiple choices with space"
-    echo -n "${bold} ? ${normal}" ; read targets # 
+    echo -n "${bold} ? ${normal}" ; read targets
     export targets=(`echo ${targets}`)
 }

--- a/main_macos.sh
+++ b/main_macos.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# If you have found some issues, or some feature request :
+# Raise them here : https://github.com/himanshub16/ProxyMan/issues
+# Author : Benjamin Gericke (@deg0nz)
+#
+
+# This is the script that provides main script functions for macOS.
+
+function _do_it_for_selection() {
+    local what_to_do="$1"
+    for t in "${targets[@]}"
+    do
+        case "$t" in
+            # THIS stmt WILL CAUSE INFINITE RECURSION. DO NOT USE THIS.
+            # COMMENTED FOR WARNING
+            # 1) _do_it_for_all "$what_to_do"
+            #    ;;
+            2) bash "bash-zsh.sh" "$what_to_do"
+                ;;
+            3) bash "npm.sh" "$what_to_do"
+                ;;
+            3) echo "networksetup not yet implemented. skipping." #bash "networksetup.sh" "$what_to_do"
+                ;;
+            4) bash "git.sh" "$what_to_do"
+                ;;
+            *) ;;
+        esac
+    done
+}
+
+function _do_it_for_all() {
+    # Argument
+    # $1 : what to do (set/unset/list)
+
+    local what_to_do="$1"
+    if [[ -z "$targets" || "$targets" = "1" ]]; then
+
+        bash "bash-zsh.sh" "$what_to_do"
+        bash "npm.sh" "$what_to_do"
+        bash "git.sh" "$what_to_do"
+
+    else
+        _do_it_for_selection "$what_to_do"
+    fi
+}
+
+function prompt_for_proxy_targets() {
+    echo "${bold}${blue} Select targets to modify ${normal}"
+
+    echo "|${bold}${red} 1 ${normal}| All of them ... Don't bother me"
+    echo "|${bold}${red} 2 ${normal}| Terminal / bash / zsh (current user) "
+    echo "|${bold}${red} 3 ${normal}| Desktop settings (networksetup)"
+    echo "|${bold}${red} 4 ${normal}| npm & yarn"
+    echo "|${bold}${red} 5 ${normal}| Git"
+    echo
+    echo "Separate multiple choices with space"
+    echo -n "${bold} ? ${normal}" ; read targets # 
+    export targets=(`echo ${targets}`)
+}

--- a/main_macos.sh
+++ b/main_macos.sh
@@ -16,9 +16,9 @@ function _do_it_for_selection() {
             # COMMENTED FOR WARNING
             # 1) _do_it_for_all "$what_to_do"
             #    ;;
-            2) bash "bash-zsh.sh" "$what_to_do"
+            2) bash "networksetup.sh" "$what_to_do"
                 ;;
-            3) bash "networksetup.sh" "$what_to_do"
+            3) bash "bash-zsh.sh" "$what_to_do"
                 ;;
             4) bash "npm.sh" "$what_to_do"
                 ;;
@@ -37,7 +37,7 @@ function _do_it_for_all() {
     if [[ -z "$targets" || "$targets" = "1" ]]; then
 
         bash "bash-zsh.sh" "$what_to_do"
-        # bash "networksetup.sh" "$what_to_do"
+        bash "networksetup.sh" "$what_to_do"
         bash "npm.sh" "$what_to_do"
         bash "git.sh" "$what_to_do"
 
@@ -50,8 +50,8 @@ function prompt_for_proxy_targets() {
     echo "${bold}${blue} Select targets to modify ${normal}"
 
     echo "|${bold}${red} 1 ${normal}| All of them ... Don't bother me"
-    echo "|${bold}${red} 2 ${normal}| Terminal / bash / zsh (current user) "
-    echo "|${bold}${red} 3 ${normal}| Desktop settings (networksetup)"
+    echo "|${bold}${red} 2 ${normal}| System-wide settings (networksetup)"
+    echo "|${bold}${red} 3 ${normal}| Terminal / bash / zsh (current user)"
     echo "|${bold}${red} 4 ${normal}| npm & yarn"
     echo "|${bold}${red} 5 ${normal}| Git"
     echo

--- a/networksetup.sh
+++ b/networksetup.sh
@@ -58,7 +58,8 @@ function _unset_proxy_for_networkservice() {
 
 function list_proxy() {
     # TODO
-    echo "Listing proxies for system on macOS is not yet implemented"
+    echo "Listing proxies for system-wide settings on macOS is not yet implemented."
+    echo "Please look into System Preferences -> Network -> <Networkdevice> -> Advanced -> Proxies for now."
 }
 
 function unset_proxy() {

--- a/networksetup.sh
+++ b/networksetup.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# If you have found some issues, or some feature request :
+# Raise them here : https://github.com/himanshub16/ProxyMan/issues
+# Author : Benjamin Gericke (@deg0nz)
+#
+
+# This is the script that provides functions for macOS's networksetup tool.
+
+function _prompt_networkservices_targets() {
+    echo "${bold}${blue} Select network interfaces to modify ${normal}"
+
+    echo "|${bold}${red} 1 ${normal}| All of them ... Don't bother me"
+    local IFS=$'\n'
+    local counter=2
+    for line in $(networksetup -listallnetworkservices); do
+        # TODO: Handle disabled services
+        if [[ "$line" == "An asterisk (*) denotes that a network service is disabled." ]]; then
+            continue
+        fi
+        echo "|${bold}${red} ${counter} ${normal}| ${line} "
+        # We write the array from 0, although 1 is "all devices"
+        # loop for selected services must be adjusted
+        arraypos="(($counter-2))"
+        networkservices_array[$arraypos]="$line"
+        ((counter++))
+    done
+    echo
+    echo "Separate multiple choices with space"
+    echo -n "${bold} ? ${normal}" ; read targets_networkservices
+    export targets_networkservices=(`echo ${targets_networkservices}`)
+}
+
+function _set_proxy_for_networkservice() {
+    local networkservice="$1"
+    # Parameters: [-setwebproxy networkservice domain portnumber authenticated username password]
+    if [[ "$use_auth" ]]; then
+        networksetup -setwebproxy "$networkservice" "$http_host" "$http_port" on "$username" "$password"
+        networksetup -setsecurewebproxy "$networkservice" "$https_host" "$https_port" on "$username" "$password"
+        networksetup -setftpproxy "$networkservice" "$http_host" "$http_port" on "$username" "$password"
+    else
+        networksetup -setwebproxy "$networkservice" "$http_host" "$http_port" off
+        networksetup -setsecurewebproxy "$networkservice" "$https_host" "$https_port" off
+        networksetup -setftpproxy "$networkservice" "$http_host" "$http_port" off
+    fi
+
+    networksetup -setproxybypassdomains "$networkservice" "$no_proxy"
+}
+
+function _unset_proxy_for_networkservice() {
+    local networkservice="$1"
+
+    networksetup -setwebproxystate "$networkservice" off
+    networksetup -setsecurewebproxystate "$networkservice" off
+    networksetup -setftpproxystate "$networkservice" off
+    networksetup -setproxyautodiscovery "$networkservice" off
+}
+
+function list_proxy() {
+    # TODO
+    echo "Listing proxies for system on macOS is not yet implemented"
+}
+
+function unset_proxy() {
+    echo "Additional information for ${bold}unsetting${normal} system-wide proxy is needed."
+
+    _prompt_networkservices_targets
+
+    if [[ -z "$targets_networkservices" || "$targets_networkservices" = "1" ]]; then
+        # Unset for all services
+        local IFS=$'\n'
+        for networkservice in ${networkservices_array[*]}; do
+            _unset_proxy_for_networkservice "$networkservice"
+        done
+    else
+        # Unset for selection
+        for arrayindex in ${targets_networkservices[@]}; do
+            # We need to correct the index, because 1 is "all devices", so all the indexes are increased by 1
+            corrected_index="(($arrayindex-2))"
+            _unset_proxy_for_networkservice "${networkservices_array[$corrected_index]}"
+        done
+    fi    
+}
+
+function set_proxy() {
+    echo "Additional information for ${bold}setting${normal} system-wide proxy is needed."
+
+    _prompt_networkservices_targets
+        
+    if [[ -z "$targets_networkservices" || "$targets_networkservices" = "1" ]]; then
+        # Set for all services
+        local IFS=$'\n'
+        for networkservice in ${networkservices_array[*]}; do
+            echo "$networkservice"
+            _set_proxy_for_networkservice "$networkservice"
+        done
+    else
+        # Set for selection of services
+        for arrayindex in ${targets_networkservices[@]}; do
+            # We need to correct the index, because 1 is "all devices", so all the indexes are increased by 1
+            corrected_index="(($arrayindex-2))"
+            _set_proxy_for_networkservice "${networkservices_array[$corrected_index]}"
+        done
+    fi
+}
+
+what_to_do=$1
+case $what_to_do in
+    set) set_proxy
+         ;;
+    unset) unset_proxy
+           ;;
+    list) list_proxy
+          ;;
+    *)
+          ;;
+esac

--- a/shellrc.sh
+++ b/shellrc.sh
@@ -25,14 +25,33 @@ unset_proxy() {
     if [ ! -e "$SHELLRC" ]; then
         return
     fi
-    # extra effort required to avoid removing custom environment variables set
-    # by the user for personal use
-    for proxytype in "http" "https" "ftp" "rsync" "no"; do
-        sed -i "/export ${proxytype}_proxy\=/d" "$SHELLRC"
-    done
-    for PROTOTYPE in "HTTP" "HTTPS" "FTP" "RSYNC" "NO"; do
-        sed -i "/export ${PROTOTYPE}_PROXY\=/d" "$SHELLRC"
-    done
+
+    # macOS ships with BSD sed, which has different syntax from GNU sed
+    case $os in
+        "Linux") 
+            # extra effort required to avoid removing custom environment variables set
+            # by the user for personal use
+            for proxytype in "http" "https" "ftp" "rsync" "no"; do
+                sed -i "/export ${proxytype}_proxy\=/d" "$SHELLRC"
+            done
+            for PROXYTYPE in "HTTP" "HTTPS" "FTP" "RSYNC" "NO"; do
+                sed -i "/export ${PROXYTYPE}_PROXY\=/d" "$SHELLRC"
+            done
+        ;;
+        "Darwin")
+            # extra effort required to avoid removing custom environment variables set
+            # by the user for personal use
+            for proxytype in "http" "https" "ftp" "rsync" "no"; do
+                sed -i "" "/export ${proxytype}_proxy\=/d" "$SHELLRC"
+            done
+            for PROXYTYPE in "HTTP" "HTTPS" "FTP" "RSYNC" "NO"; do
+                sed -i "" "/export ${PROXYTYPE}_PROXY\=/d" "$SHELLRC"
+            done
+        ;;
+        *) echo "Operating system not supported. Exiting."
+        exit 1
+        ;;
+    esac
 }
 
 set_proxy() {

--- a/variables.sh
+++ b/variables.sh
@@ -36,6 +36,7 @@ fi
 export config_dir="$HOME/.config/proxyman"
 export default_config="default"
 export SHELLRC="$HOME/.bashrc"
+export os=`uname`
 
 case "$SHELL" in
     "$(which bash)") SHELLRC="$HOME/.bashrc"


### PR DESCRIPTION
I added the support for macOS for ProxyMan. I created this PR so we can discuss some stuff about the implementation.

For now, the following things are implemented:

* Change system-wide settings (`networksetup` as mentioned in #11 )
  *  On macOS, proxy settings are set per network device. So I added a second selection prompt to determine for which network devices proxies should be set.
* Terminal's settings work as before, but some adjustments were needed to work on macOS
* Configurations for `npm`/`yarn` and `git` are untouched since they are identical to Linux
* non-macOS related configurations (like KDE, `apt`, `docker`, ...) are ignored in the macOS-part

What's missing:

* Printing `networksetup` proxy configurations. To make this pretty, there is need for some data aggregation to be made, since `networksetup` is a bit chatty about that. A simple print for all network devices would be too much. So I left that part out for now.
* I think setting variables other than the ones for the Terminal environment as mentioned in #12 is not necessary, because the configurations via `networksetup` are system-wide
* I would like to add auto-discovery for proxies additionally to setting the proxies manually per-device since macOS supports this function later

To be done before merging:

* I'm not so happy with the file names of the splitted functions for macOS and Linux (respectively `main_macos.sh` and `main_linux.sh`) because they can cause confusion by the user (one could think that those are the `main.sh` to be executed for the corresponding OS). I will change this to something that makes more sense for this scenario.
