### PR TITLE
adding unset command to bashrc

### DIFF
--- a/shellrc.sh
+++ b/shellrc.sh
@@ -29,10 +29,32 @@ unset_proxy() {
     # by the user for personal use
     for proxytype in "http" "https" "ftp" "rsync" "no"; do
         sed -i "/export ${proxytype}_proxy\=/d" "$SHELLRC"
+        sed -i "/unset ${proxytype}/d" "$SHELLRC"
     done
     for PROTOTYPE in "HTTP" "HTTPS" "FTP" "RSYNC" "NO"; do
         sed -i "/export ${PROTOTYPE}_PROXY\=/d" "$SHELLRC"
+        sed -i "/unset ${PROTOTYPE}/d" "$SHELLRC"
     done
+
+    # caution: do not use / after stmt
+    echo "unset http_proxy"     >> "$SHELLRC"
+    # $https_proxy at the end
+    echo "unset ftp_proxy"         >> "$SHELLRC"
+    echo "unset rsync_proxy" >> "$SHELLRC"
+    echo "unset no_proxy"                                    >> "$SHELLRC"
+    echo "unset HTTP_PROXY"     >> "$SHELLRC"
+    # $HTTPS_PROXY at the end
+    echo "unset FTP_PROXY"         >> "$SHELLRC"
+    echo "unset RSYNC_PROXY" >> "$SHELLRC"
+    echo "unset NO_PROXY"                                    >> "$SHELLRC"
+
+    if [ "$USE_HTTP_PROXY_FOR_HTTPS" = "true" ]; then
+        echo "unset https_proxy" >> "$SHELLRC"
+        echo "unset HTTPS_PROXY" >> "$SHELLRC"
+    else
+        echo "unset https_proxy" >> "$SHELLRC"
+        echo "unset HTTPS_PROXY" >> "$SHELLRC"
+    fi
 }
 
 set_proxy() {

--- a/shellrc.sh
+++ b/shellrc.sh
@@ -68,25 +68,44 @@ set_proxy() {
         stmt="${username}:${password}@"
     fi
 
-    # caution: do not use / after stmt
-    echo "export http_proxy=\"http://${stmt}${http_host}:${http_port}/\""     >> "$SHELLRC"
-    # $https_proxy at the end
-    echo "export ftp_proxy=\"ftp://${stmt}${ftp_host}:${ftp_port}/\""         >> "$SHELLRC"
-    echo "export rsync_proxy=\"rsync://${stmt}${rsync_host}:${rsync_port}/\"" >> "$SHELLRC"
-    echo "export no_proxy=\"${no_proxy}\""                                    >> "$SHELLRC"
-    echo "export HTTP_PROXY=\"http://${stmt}${http_host}:${http_port}/\""     >> "$SHELLRC"
-    # $HTTPS_PROXY at the end
-    echo "export FTP_PROXY=\"ftp://${stmt}${ftp_host}:${ftp_port}/\""         >> "$SHELLRC"
-    echo "export RSYNC_PROXY=\"rsync://${stmt}${rsync_host}:${rsync_port}/\"" >> "$SHELLRC"
-    echo "export NO_PROXY=\"${no_proxy}\""                                    >> "$SHELLRC"
-
-    if [ "$USE_HTTP_PROXY_FOR_HTTPS" = "true" ]; then
+    if [[ $use_same == "y" ]]; then
+       # caution: do not use / after stmt
+        echo "export http_proxy=\"http://${stmt}${http_host}:${http_port}/\""     >> "$SHELLRC"
+        # $https_proxy at the end
+        echo "export ftp_proxy=\"http://${stmt}${ftp_host}:${ftp_port}/\""         >> "$SHELLRC"
+        echo "export rsync_proxy=\"http://${stmt}${rsync_host}:${rsync_port}/\"" >> "$SHELLRC"
+        echo "export no_proxy=\"${no_proxy}\""                                    >> "$SHELLRC"
+        echo "export HTTP_PROXY=\"http://${stmt}${http_host}:${http_port}/\""     >> "$SHELLRC"
+        # $HTTPS_PROXY at the end
+        echo "export FTP_PROXY=\"http://${stmt}${ftp_host}:${ftp_port}/\""         >> "$SHELLRC"
+        echo "export RSYNC_PROXY=\"http://${stmt}${rsync_host}:${rsync_port}/\"" >> "$SHELLRC"
+        echo "export NO_PROXY=\"${no_proxy}\""                                    >> "$SHELLRC"
         echo "export https_proxy=\"http://${stmt}${http_host}:${http_port}/\"" >> "$SHELLRC"
         echo "export HTTPS_PROXY=\"http://${stmt}${http_host}:${http_port}/\"" >> "$SHELLRC"
     else
-        echo "export https_proxy=\"https://${stmt}${https_host}:${https_port}/\"" >> "$SHELLRC"
-        echo "export HTTPS_PROXY=\"https://${stmt}${https_host}:${https_port}/\"" >> "$SHELLRC"
+        # caution: do not use / after stmt
+        echo "export http_proxy=\"http://${stmt}${http_host}:${http_port}/\""     >> "$SHELLRC"
+        # $https_proxy at the end
+        echo "export ftp_proxy=\"ftp://${stmt}${ftp_host}:${ftp_port}/\""         >> "$SHELLRC"
+        echo "export rsync_proxy=\"rsync://${stmt}${rsync_host}:${rsync_port}/\"" >> "$SHELLRC"
+        echo "export no_proxy=\"${no_proxy}\""                                    >> "$SHELLRC"
+        echo "export HTTP_PROXY=\"http://${stmt}${http_host}:${http_port}/\""     >> "$SHELLRC"
+        # $HTTPS_PROXY at the end
+        echo "export FTP_PROXY=\"ftp://${stmt}${ftp_host}:${ftp_port}/\""         >> "$SHELLRC"
+        echo "export RSYNC_PROXY=\"rsync://${stmt}${rsync_host}:${rsync_port}/\"" >> "$SHELLRC"
+        echo "export NO_PROXY=\"${no_proxy}\""                                    >> "$SHELLRC"
+
+        if [ "$USE_HTTP_PROXY_FOR_HTTPS" = "true" ]; then
+            echo "export https_proxy=\"http://${stmt}${http_host}:${http_port}/\"" >> "$SHELLRC"
+            echo "export HTTPS_PROXY=\"http://${stmt}${http_host}:${http_port}/\"" >> "$SHELLRC"
+        else
+            echo "export https_proxy=\"https://${stmt}${https_host}:${https_port}/\"" >> "$SHELLRC"
+            echo "export HTTPS_PROXY=\"https://${stmt}${https_host}:${https_port}/\"" >> "$SHELLRC"
+        fi
     fi
+
+
+    
 }
 
 


### PR DESCRIPTION
current unset command doesn't remove current proxy envars forcing to logout because proxyman only removes export sentence and while executing source ~/.bashrc leaves current envar configured