### PR TITLE
Give the choice not to set a proxy for HTTPS or FTP connections.

### DIFF
--- a/apt.sh
+++ b/apt.sh
@@ -47,14 +47,16 @@ set_proxy() {
     echo "Acquire::Http::Proxy \"http://${stmt}${http_host}:${http_port}\";" \
          >> "$CONF_FILE"
     if [ "$USE_HTTP_PROXY_FOR_HTTPS" = "true" ]; then
-        echo "Acquire::Https::Proxy \"http://${stmt}${https_host}:${https_port}\";" \
+        echo "Acquire::Https::Proxy \"http://${stmt}${http_host}:${http_port}\";" \
          >> "$CONF_FILE"
-    else
+    elif [ -n "$https_host" ]; then
         echo "Acquire::Https::Proxy \"https://${stmt}${https_host}:${https_port}\";" \
          >> "$CONF_FILE"
     fi
-    echo "Acquire::Ftp::Proxy \"ftp://${stmt}${ftp_host}:${ftp_port}\";" \
+    if [ -n "$ftp_host" ]; then
+        echo "Acquire::Ftp::Proxy \"ftp://${stmt}${ftp_host}:${ftp_port}\";" \
          >> "$CONF_FILE"
+    fi
 }
 
 

--- a/configs.sh
+++ b/configs.sh
@@ -17,7 +17,7 @@
 function list_configs() {
     # Arguments : None
 
-    echo "${bold}${cyan}Here are available configs!${normal}"
+    echo "${bold}${cyan}Here are the available configs!${normal}"
     ls -1 $config_dir
 }
 

--- a/git.sh
+++ b/git.sh
@@ -24,8 +24,8 @@ set_proxy() {
     # caution: do not use / after stmt
     git config --global http.proxy "http://${stmt}${http_host}:${http_port}/"
     if [ "$USE_HTTP_PROXY_FOR_HTTPS" = "true" ]; then
-        git config --global https.proxy "http://${stmt}${https_host}:${https_port}/"
-    else
+        git config --global https.proxy "http://${stmt}${http_host}:${http_port}/"
+    elif [ -n "$https_host" ]; then
         git config --global https.proxy "https://${stmt}${https_host}:${https_port}/"
     fi
 }

--- a/gsettings.sh
+++ b/gsettings.sh
@@ -41,10 +41,14 @@ set_proxy() {
     gsettings set org.gnome.system.proxy mode "manual"
     gsettings set org.gnome.system.proxy.http host "$http_host"
     gsettings set org.gnome.system.proxy.http port "$http_port"
-    gsettings set org.gnome.system.proxy.https host "$https_host"
-    gsettings set org.gnome.system.proxy.https port "$https_port"
-    gsettings set org.gnome.system.proxy.ftp host "$ftp_host"
-    gsettings set org.gnome.system.proxy.ftp port "$ftp_port"
+    if [ -n "$https_host" ]; then
+        gsettings set org.gnome.system.proxy.https host "$https_host"
+        gsettings set org.gnome.system.proxy.https port "$https_port"
+    fi
+    if [ -n "$ftp_host"]; then
+        gsettings set org.gnome.system.proxy.ftp host "$ftp_host"
+        gsettings set org.gnome.system.proxy.ftp port "$ftp_port"
+    fi
     gsettings set org.gnome.system.proxy.http authentication-password "$password"
     gsettings set org.gnome.system.proxy.http authentication-user "$username"
 

--- a/kde5.sh
+++ b/kde5.sh
@@ -32,8 +32,12 @@ set_proxy() {
     # do quote the variables as blank variables mean nothing when not quoted and show errors
     kwriteconfig5 --file kioslaverc --group "Proxy Settings" --key ProxyType 1
     kwriteconfig5 --file kioslaverc --group "Proxy Settings" --key httpProxy "http://$http_host $http_port"
-    kwriteconfig5 --file kioslaverc --group "Proxy Settings" --key httpsProxy "http://$https_host $https_port"
-    kwriteconfig5 --file kioslaverc --group "Proxy Settings" --key ftpProxy "ftp://$ftp_host $ftp_port"
+    if [ -n "$https_host" ]; then
+        kwriteconfig5 --file kioslaverc --group "Proxy Settings" --key httpsProxy "http://$https_host $https_port"
+    fi
+    if [ -n "$ftp_host" ]; then
+        kwriteconfig5 --file kioslaverc --group "Proxy Settings" --key ftpProxy "ftp://$ftp_host $ftp_port"
+    fi
     if [[ "$socks_host" != "" ]]; then
         kwriteconfig5 --file kioslaverc --group "Proxy Settings" --key socksProxy "socks://$socks_host $socks_port"
     else

--- a/npm.sh
+++ b/npm.sh
@@ -30,7 +30,7 @@ set_proxy() {
 
     if [ "$USE_HTTP_PROXY_FOR_HTTPS" = "true" ]; then
         npm config set https-proxy "http://${stmt}${http_host}:${http_port}/"
-    else
+    elif [ -n "$https_host" ]; then
         npm config set https-proxy "https://${stmt}${https_host}:${https_port}/"
     fi
 }

--- a/shellrc.sh
+++ b/shellrc.sh
@@ -49,19 +49,21 @@ set_proxy() {
     # caution: do not use / after stmt
     echo "export http_proxy=\"http://${stmt}${http_host}:${http_port}/\""     >> "$SHELLRC"
     # $https_proxy at the end
-    echo "export ftp_proxy=\"ftp://${stmt}${ftp_host}:${ftp_port}/\""         >> "$SHELLRC"
     echo "export rsync_proxy=\"rsync://${stmt}${rsync_host}:${rsync_port}/\"" >> "$SHELLRC"
     echo "export no_proxy=\"${no_proxy}\""                                    >> "$SHELLRC"
     echo "export HTTP_PROXY=\"http://${stmt}${http_host}:${http_port}/\""     >> "$SHELLRC"
     # $HTTPS_PROXY at the end
-    echo "export FTP_PROXY=\"ftp://${stmt}${ftp_host}:${ftp_port}/\""         >> "$SHELLRC"
+    if [ -n "$ftp_host" ]; then
+        echo "export ftp_proxy=\"ftp://${stmt}${ftp_host}:${ftp_port}/\""         >> "$SHELLRC"
+        echo "export FTP_PROXY=\"ftp://${stmt}${ftp_host}:${ftp_port}/\""         >> "$SHELLRC"
+    fi
     echo "export RSYNC_PROXY=\"rsync://${stmt}${rsync_host}:${rsync_port}/\"" >> "$SHELLRC"
     echo "export NO_PROXY=\"${no_proxy}\""                                    >> "$SHELLRC"
 
     if [ "$USE_HTTP_PROXY_FOR_HTTPS" = "true" ]; then
         echo "export https_proxy=\"http://${stmt}${http_host}:${http_port}/\"" >> "$SHELLRC"
         echo "export HTTPS_PROXY=\"http://${stmt}${http_host}:${http_port}/\"" >> "$SHELLRC"
-    else
+    elif [ -n "$https_host" ]; then
         echo "export https_proxy=\"https://${stmt}${https_host}:${https_port}/\"" >> "$SHELLRC"
         echo "export HTTPS_PROXY=\"https://${stmt}${https_host}:${https_port}/\"" >> "$SHELLRC"
     fi


### PR DESCRIPTION
These modifications were taken from @lgenzelis repository and they do not set HTTPS or FTP proxy if the user set those values blank wile configuring them.

This pull request is able to merge automatically with the current master branch.